### PR TITLE
update I2C api and copyright order

### DIFF
--- a/example/src/main/kotlin/I2CExample.kt
+++ b/example/src/main/kotlin/I2CExample.kt
@@ -20,20 +20,6 @@ import com.pi4j.ktx.pi4j
 import com.pi4j.ktx.utils.binStr
 import java.lang.Thread.sleep
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 
 private const val TCA9534_REG_ADDR_OUT_PORT: Int = 0x01
 private const val TCA9534_REG_ADDR_CFG: Int = 0x03

--- a/lib/src/main/kotlin/com/pi4j/ktx/io/I2C.kt
+++ b/lib/src/main/kotlin/com/pi4j/ktx/io/I2C.kt
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.pi4j.ktx.io
 
 import com.pi4j.context.Context
@@ -57,7 +43,7 @@ fun I2C.setPin(currentState: Int, pin: Int, regOutPort: Int, high: Boolean = tru
     return newState
 }
 
-fun I2CConfigBuilder.mockI2cProvider() {
+fun I2CConfigBuilder.mockI2CProvider() {
     provider(Provider.MOCK_I2C.id)
 }
 

--- a/lib/src/test/kotlin/com/pi4j/ktx/io/I2CTest.kt
+++ b/lib/src/test/kotlin/com/pi4j/ktx/io/I2CTest.kt
@@ -12,20 +12,6 @@
  * limitations under the License.
  */
 
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.pi4j.ktx.io
 
 import com.pi4j.Pi4J
@@ -53,12 +39,12 @@ internal class I2CTest {
     @Test
     fun `test i2c creation`() {
         context.run {
-            val i2CProvider: I2CProvider = context.provider("mock-i2c")
+            val i2CProvider: I2CProvider = context.provider<I2CProvider>("mock-i2c")
             val javaI2C =
                 i2CProvider.create(I2C.newConfigBuilder(context).id("TCA9534").bus(1).device(0x3f).build())
 
             val kotlinI2C = i2c(2, 0x3f) {
-                mockI2cProvider()
+                mockI2CProvider()
             }
 
             assertEquals(javaI2C::class.java, kotlinI2C::class.java)
@@ -68,7 +54,7 @@ internal class I2CTest {
                 i2CProvider.create(I2C.newConfigBuilder(context).id("TCA9534").bus(1).device(0x4f).build())
                 i2c(1, 0x4f) {
                     id("TCA9534")
-                    mockI2cProvider()
+                    mockI2CProvider()
                 }
             }
         }


### PR DESCRIPTION
updated naming convention for `I2C` instead of `I2c`